### PR TITLE
FIX Always set color

### DIFF
--- a/bin/widget/view/tree_gtk/parser.py
+++ b/bin/widget/view/tree_gtk/parser.py
@@ -246,8 +246,9 @@ class Char(object):
             self.state_set(model, model.value.get('state','draft'))
         self.attrs_set(model, cell)
         color = self.get_color(model)
-        if color :
-            cell.set_property('foreground', str(color))
+        if color is not None:
+            color = str(color)
+        cell.set_property('foreground', color)
         if self.attrs['type'] in ('float', 'integer', 'boolean'):
             align = 1
         else:


### PR DESCRIPTION
Commit https://github.com/gisce/erpclient/pull/18/commits/d0841c82767f25a284d0d78c15a3efebcd7f554f broke the alternation between colors in a tree view as if no color set, last row color was used. Color should always be set.

GTK CellRendererText object accepts None as a value for "foreground" ([GTK Reference link](http://www.pygtk.org/pygtk2reference/class-gtkcellrenderertext.html)) , and this way theme color should be respected.