### PR TITLE
Fix del filtro de ficheros de los binary fields

### DIFF
--- a/bin/widget/view/form_gtk/binary.py
+++ b/bin/widget/view/form_gtk/binary.py
@@ -134,10 +134,13 @@ class wid_binary(interface.widget_interface):
                 filter_file.add_pattern('*')
                 filters.append(filter_file)
             else:
-                for pat in self.filters:
+                filter_file = None
+                if self.filters:
                     filter_file = gtk.FileFilter()
-                    filter_file.set_name(str(pat))
-                    filter_file.add_pattern(pat)
+                    for pat in self.filters:
+                        filter_file.set_name(str(pat))
+                        filter_file.add_pattern(pat)
+                if filter_file is not None:
                     filters.append(filter_file)
 
             filename = common.file_selection(_('Select a file...'), parent=self._window,filters=filters)


### PR DESCRIPTION
## Description
Los filtros custom de ficheros no funcionavan correctamente, ya que dada la logica del código no aplicava correctamente los filtros y no aparecian los ficheros del tipo especificado durante la busqueda

### Ejemplo de codigo donde se usan los filtros
```python
'arxiu': fields.binary(
            'Arxiu', required=True, filters='*.txt,*.xml,*.zip'
        ),
```

## Tasks

- [x] Reparar filtro de ficheros para que filtre correctamete para las extensiones especificadas