### PR TITLE
Keep sorted tree when coming back from form

### DIFF
--- a/bin/release.py
+++ b/bin/release.py
@@ -20,7 +20,7 @@
 #
 
 name = 'openerp-client'
-version = '5.0.28'
+version = '5.0.29-pre'
 description = 'OpenERP Client'
 long_desc = '''OpenERP is a complete ERP and CRM. The main features are accounting (analytic
 and financial), stock management, sales and purchases management, tasks

--- a/bin/release.py
+++ b/bin/release.py
@@ -20,7 +20,7 @@
 #
 
 name = 'openerp-client'
-version = '5.1.0'
+version = '5.1.1-pre'
 description = 'OpenERP Client'
 long_desc = '''OpenERP is a complete ERP and CRM. The main features are accounting (analytic
 and financial), stock management, sales and purchases management, tasks


### PR DESCRIPTION
## Goal

Keep sorted the tree view when coming back from the form view.

## Old behavior

1. Sort a tree view
2. Go to the form view
2. Come back to the tree view: the rows are no longer sorted.

## New behavior
 
1. Sort a tree view
2. Go to the form view
2. Come back to the tree view: the rows are sorted.

### Note:

The **first** sort of a numerical column is descendant (originally was ascendant).

## Checklist:

- [x] Sort the tree when coming back from the form view.
