### PR TITLE
Only fetch necessary fields when openening a tree view.

### DIFF
--- a/bin/widget/model/group.py
+++ b/bin/widget/model/group.py
@@ -175,15 +175,18 @@ class ModelRecordGroup(signal_event.signal_event):
             self.models.lock_signal = False
             self.signal('record-cleared')
 
-    def load(self, ids, display=True):
+    def load(self, ids, display=True, fetch_fields=None):
         if not ids:
             return True
         if not self.fields:
             return self.pre_load(ids, display)
+        if fetch_fields is None:
+            fetch_fields = self.fields.keys()
+
         c = rpc.session.context.copy()
         c.update(self.context)
         c['bin_size'] = True
-        values = self.rpc.read(ids, self.fields.keys() + [rpc.CONCURRENCY_CHECK_FIELD], c)
+        values = self.rpc.read(ids, fetch_fields + [rpc.CONCURRENCY_CHECK_FIELD], c)
         if not values:
             return False
         newmod = False

--- a/bin/widget/screen/screen.py
+++ b/bin/widget/screen/screen.py
@@ -552,7 +552,7 @@ class Screen(signal_event.signal_event):
     def load(self, ids):
         if not isinstance(ids,list):
             ids = [ids]
-        self.models.load(ids, display=False)
+        self.models.load(ids, display=False, fetch_fields=self.fields.keys())
         self.current_view.reset()
         if ids:
             self.display(ids[0])


### PR DESCRIPTION
## Goal

Only fetch the fields that are shown in the tree view.

## Old behavior

The client always fetch all the fields of the model.

## New behavior

The client only fetch the fields that are shown on the tree view.

## Checklist:

- [x] On `load` function, pass the fields to be fetched that are shown on the view.
