### PR TITLE
Mejoras en el protocolo MsgPack

### DIFF
--- a/bin/compat.py
+++ b/bin/compat.py
@@ -1,0 +1,31 @@
+import sys
+import logging
+
+
+logger = logging.getLogger('common.compat')
+
+
+if sys.version_info < (2, 7):
+    import urllib2
+
+    class HTTPErrorProcessor(urllib2.HTTPErrorProcessor):
+        """Process HTTP error responses."""
+        handler_order = 1000  # after all other processing
+
+        def http_response(self, request, response):
+            code, msg, hdrs = response.code, response.msg, response.info()
+
+            # According to RFC 2616, "2xx" code indicates that the client's
+            # request was successfully received, understood, and accepted.
+            if not (200 <= code < 300):
+                response = self.parent.error(
+                    'http', request, response, code, msg, hdrs)
+
+            return response
+
+        https_response = http_response
+
+
+    logger.info("Install custom opener...")
+    opener = urllib2.build_opener(HTTPErrorProcessor)
+    urllib2.install_opener(opener)

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -441,7 +441,8 @@ def _server_ask(server_widget, parent=None):
     protocol = {
         'XML-RPC': 'http://',
         'NET-RPC (faster)': 'socket://',
-        'MsgPack': 'http+msgpack://'
+        'MsgPack': 'http+msgpack://',
+        'MsgPack SSL': 'https+msgpack://'
     }
 
     if check_ssl():
@@ -457,7 +458,7 @@ def _server_ask(server_widget, parent=None):
 
     index = 0
     i = 0
-    for p in protocol:
+    for p in sorted(protocol):
         listprotocol.append([p])
         if m and protocol[p] == m.group(1):
             index = i

--- a/bin/openerp-client.py
+++ b/bin/openerp-client.py
@@ -43,6 +43,7 @@ import logging
 arguments = {}
 if sys.platform == 'win32':
     arguments['filename'] = os.path.join(os.environ['USERPROFILE'], 'openerp-client.log')
+import compat
 
 logging.basicConfig(**arguments)
 

--- a/bin/release.py
+++ b/bin/release.py
@@ -20,7 +20,7 @@
 #
 
 name = 'openerp-client'
-version = '5.2.2'
+version = '5.2.3-rc1'
 description = 'OpenERP Client'
 long_desc = '''OpenERP is a complete ERP and CRM. The main features are accounting (analytic
 and financial), stock management, sales and purchases management, tasks

--- a/bin/release.py
+++ b/bin/release.py
@@ -20,7 +20,7 @@
 #
 
 name = 'openerp-client'
-version = '5.2.3-rc2'
+version = '5.2.3-rc3'
 description = 'OpenERP Client'
 long_desc = '''OpenERP is a complete ERP and CRM. The main features are accounting (analytic
 and financial), stock management, sales and purchases management, tasks

--- a/bin/rpc.py
+++ b/bin/rpc.py
@@ -157,7 +157,7 @@ class msgpack_gw(gw_inter):
         return res
 
     def execute(self, method, *args):
-        endpoint = '%s/%s' % (self._url, self._obj)
+        endpoint = '%s%s' % (self._url, self._obj)
         m = msgpack.packb([method, self._db] + list(args))
         u = urllib2.urlopen(endpoint, m)
         s = u.read()
@@ -350,7 +350,7 @@ class rpc_session(object):
         if m.group(1) == 'http://' or m.group(1) == 'https://':
             sock = xmlrpclib.ServerProxy(url + '/xmlrpc/' + resource)
             return getattr(sock, method)(*args)
-        elif m.group(1) == 'http+msgpack://':
+        elif m.group(1).endswith('+msgpack://'):
             endpoint = '%s/%s' % (url.replace('+msgpack', ''), resource)
             m = msgpack.packb([method] + list(args))
             u = urllib2.urlopen(endpoint, m)

--- a/bin/rpc.py
+++ b/bin/rpc.py
@@ -151,7 +151,6 @@ class msgpack_gw(gw_inter):
 
     def __init__(self, url, db, uid, passwd, obj='/object'):
         super(msgpack_gw, self).__init__(url, db, uid, passwd, obj)
-        self._sock = tiny_socket.mysocket()
 
     def exec_auth(self, method, *args):
         res = self.execute(method, self._uid, self._passwd, *args)
@@ -273,12 +272,12 @@ class rpc_session(object):
                 self._open=False
                 self.uid=False
                 return -2
-        elif _protocol == 'http+msgpack://':
-            _url = 'http://%s:%s' % (url, port)
+        elif _protocol.endswith('+msgpack://'):
+            _url = '%s://%s:%s' % (_protocol.split('+')[0], url, port)
             self._gw = msgpack_gw
             try:
                 m = msgpack.packb(['login', db or '', uname or '', passwd or ''])
-                u = urllib2.urlopen('http://%s:%s/common' % (url, port), m)
+                u = urllib2.urlopen('%s/common' % _url, m)
                 s = u.read()
                 u.close()
                 res = msgpack.unpackb(s)

--- a/bin/rpc.py
+++ b/bin/rpc.py
@@ -160,10 +160,7 @@ class msgpack_gw(gw_inter):
     def execute(self, method, *args):
         endpoint = '%s/%s' % (self._url, self._obj)
         m = msgpack.packb([method, self._db] + list(args))
-        try:
-            u = urllib2.urlopen(endpoint, m)
-        except urllib2.HTTPError:
-            pass
+        u = urllib2.urlopen(endpoint, m)
         s = u.read()
         u.close()
         res = msgpack.unpackb(s)


### PR DESCRIPTION
- Soporte para MsgPack con SSL
- Capturación de errores
Los errores de MsgPack no daban información del error, sino que siempre se quedaban en **error 500**, ahora se gestionan igual que el protocolo XML-RPC