### PR TITLE
Añadir limite de busqueda como parámetro del cliente

### DIFF
--- a/bin/modules/action/main.py
+++ b/bin/modules/action/main.py
@@ -97,8 +97,7 @@ class main(service.Service):
                     'limit', 'auto_refresh'):
                 datas[key] = action.get(key, datas.get(key, None))
 
-            if datas['limit'] is None or datas['limit'] == 0:
-                datas['limit'] = 80
+            datas['limit'] = int(os.environ["SEARCH_LIMIT"])
 
             view_ids=False
             if action.get('views', []):

--- a/bin/modules/action/main.py
+++ b/bin/modules/action/main.py
@@ -97,7 +97,8 @@ class main(service.Service):
                     'limit', 'auto_refresh'):
                 datas[key] = action.get(key, datas.get(key, None))
 
-            datas['limit'] = int(os.environ["SEARCH_LIMIT"])
+            #if datas['limit'] is None or datas['limit'] == 0:
+            datas['limit'] = int(os.environ["SEARCH_LIMIT"]) if 'SEARCH_LIMIT' in os.environ else 40
 
             view_ids=False
             if action.get('views', []):

--- a/bin/modules/gui/main.py
+++ b/bin/modules/gui/main.py
@@ -436,6 +436,7 @@ def _server_ask(server_widget, parent=None):
     win.set_default_response(gtk.RESPONSE_OK)
     host_widget = win_gl.get_widget('ent_host')
     port_widget = win_gl.get_widget('ent_port')
+    search_limit = win_gl.get_widget('limit_number')
     protocol_widget = win_gl.get_widget('protocol')
 
     protocol = {
@@ -466,6 +467,7 @@ def _server_ask(server_widget, parent=None):
 
     res = win.run()
     if res == gtk.RESPONSE_OK:
+        os.environ["SEARCH_LIMIT"] = search_limit.get_text()
         protocol = protocol[protocol_widget.get_active_text()]
         url = '%s%s:%s' % (protocol, host_widget.get_text(), port_widget.get_text())
         server_widget.set_text(url)

--- a/bin/openerp.glade
+++ b/bin/openerp.glade
@@ -6255,7 +6255,7 @@ Latin1</property>
           <widget class="GtkTable" id="table16">
             <property name="visible">True</property>
             <property name="border_width">12</property>
-            <property name="n_rows">3</property>
+            <property name="n_rows">4</property>
             <property name="n_columns">2</property>
             <property name="row_spacing">6</property>
             <child>
@@ -6298,6 +6298,37 @@ Latin1</property>
                 <property name="top_attach">2</property>
                 <property name="bottom_attach">3</property>
                 <property name="x_options">GTK_FILL</property>
+                <property name="y_options"></property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkEntry" id="limit_number">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="activates_default">True</property>
+                <property name="width_chars">16</property>
+                <property name="max_length">3</property>
+                <property name="text">40</property>
+              </widget>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">3</property>
+                <property name="bottom_attach">4</property>
+                <property name="y_options"></property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="label_limit">
+                <property name="visible">True</property>
+                <property name="xalign">1</property>
+                <property name="xpad">3</property>
+                <property name="ypad">3</property>
+                <property name="label" translatable="yes">Limit de cerca:</property>
+              </widget>
+              <packing>
+                <property name="top_attach">3</property>
+                <property name="bottom_attach">4</property>
                 <property name="y_options"></property>
               </packing>
             </child>

--- a/bin/widget/screen/screen.py
+++ b/bin/widget/screen/screen.py
@@ -354,6 +354,11 @@ class Screen(signal_event.signal_event):
             return self.add_view(view['arch'], view['fields'], display,
                     toolbar=view.get('toolbar', False), context=ctx)
 
+    def clean_models(self):
+        ''' Clean self.models to remove models != current_model'''
+        self.models.models.clear()
+        self.models.models.append(self.current_model)
+
     def add_view(self, arch, fields, display=False, custom=False, toolbar=None,
             context=None):
         if toolbar is None:
@@ -385,6 +390,8 @@ class Screen(signal_event.signal_event):
         if custom:
             self.models.add_fields_custom(fields, self.models)
         else:
+            if self.current_model:
+                self.clean_models()
             self.models.add_fields(fields, self.models, context=context)
         self.fields = self.models.fields
 


### PR DESCRIPTION
## Objetivos

- Limitar los listados por defecto al cargar el tree 

## Comportamiento antiguo

- Limite en 80 elementos

## Comportamiento nuevo

- Limite por defecto en 40 elementos, se puede modificar por el numero deseado

## Variables de configuración

- Variable de sistema SEARCH_LIMIT

## Relacionado

![limitador_de_cerca](https://user-images.githubusercontent.com/12842454/78898983-00b75a80-7a75-11ea-8b6e-c451050dcc2c.gif)

Se modifica el menú de parametros de conexion del cliente