### PR TITLE
IMP Show required field in stdout

### DIFF
--- a/bin/widget/model/record.py
+++ b/bin/widget/model/record.py
@@ -183,6 +183,7 @@ class ModelRecord(signal_event.signal_event):
         ok = True
         for fname in self.mgroup.mfields:
             if not self.mgroup.mfields[fname].validate(self):
+                print("Not valid field: {}".format(fname))
                 ok = False
         return ok
 


### PR DESCRIPTION
Sometimes, when a field is required, the client doesn't shows it in red (i.e. readonly).
Now, the field is writen to stdout