### PR TITLE
Arreglar búsqueda por id al capturar el evento de tecla Enter

### DIFF
--- a/bin/modules/gui/window/form.py
+++ b/bin/modules/gui/window/form.py
@@ -173,7 +173,7 @@ class form(object):
     def get_event(self, widget, event, win):
         if event.keyval in (gtk.keysyms.Return, gtk.keysyms.KP_Enter):
             win.destroy()
-            self.get_resource(widget)
+            self.get_one_resource(widget)
         
         
     def sig_goto(self, *args):


### PR DESCRIPTION
* Hasta ahora solamente se llamaba la función `get_one_resource` cuando la respuesta de gtk era del tipo `gtk.RESPONSE_OK`
omitiento el caso que se presionara la tecla Enter.

* Se soluciona éste problema substituyendo  `get_resource` por  `get_one_resource` en `get_event`