### PR TITLE
Añadidos `limit` y `offset` en el `screen_container`

### DIFF
--- a/bin/widget/screen/screen.py
+++ b/bin/widget/screen/screen.py
@@ -144,7 +144,9 @@ class Screen(signal_event.signal_event):
                         self.search_offset_next,
                         self.search_offset_previous)
                 self.filter_widget.set_limit(self.limit)
-                
+                self.screen_container.spin_limit.set_value(self.limit)
+                self.filter_widget.set_offset(self.screen_container.spin_offset.get_value())
+
         if active and show_search:
             self.screen_container.show_filter()
         else:
@@ -164,16 +166,30 @@ class Screen(signal_event.signal_event):
             self.screen_container.but_next.set_sensitive(True)
 
     def search_offset_next(self, *args):
-        offset=self.filter_widget.get_offset()
-        limit=self.filter_widget.get_limit()
-        self.filter_widget.set_offset(offset+limit)
+        offset=self.search_offset_add()
+        limit=self.search_limit_add()
+        new_offset=offset+limit
+        self.screen_container.spin_offset.set_value(new_offset)
+        self.filter_widget.set_offset(new_offset)
         self.search_filter()
 
     def search_offset_previous(self, *args):
-        offset=self.filter_widget.get_offset()
-        limit=self.filter_widget.get_limit()
-        self.filter_widget.set_offset(max(offset-limit,0))
+        offset=self.search_offset_add()
+        limit=self.search_limit_add()
+        new_offset=max(offset-limit,0)
+        self.screen_container.spin_offset.set_value(new_offset)
+        self.filter_widget.set_offset(new_offset)
         self.search_filter()
+
+    def search_limit_add(self, *args):
+        spin_limit_sc =  self.screen_container.spin_limit.get_value()
+        self.filter_widget.set_limit(spin_limit_sc)
+        return spin_limit_sc
+
+    def search_offset_add(self, *args):
+        spin_offset_sc = self.screen_container.spin_offset.get_value()
+        self.filter_widget.set_offset(spin_offset_sc)
+        return spin_offset_sc
 
     def search_clear(self, *args):
         self.filter_widget.clear()
@@ -196,7 +212,11 @@ class Screen(signal_event.signal_event):
         if self.latest_search != v:
             self.filter_widget.set_offset(0)
         limit=self.filter_widget.get_limit()
+        limit=self.search_limit_add()
+
         offset=self.filter_widget.get_offset()
+        offset=self.search_offset_add()
+
         self.latest_search = v
         ids = rpc.session.rpc_exec_auth('/object', 'execute', self.name, 'search', v, offset, limit, 0, self.context)
         if len(ids) < limit:

--- a/bin/widget/screen/screen.py
+++ b/bin/widget/screen/screen.py
@@ -33,6 +33,7 @@ import signal_event
 import tools
 import service
 import copy
+import gtk
 
 
 class Screen(signal_event.signal_event):
@@ -112,6 +113,10 @@ class Screen(signal_event.signal_event):
 
     readonly = property(readonly_get, readonly_set)
 
+    def get_event(self, widget, event):
+        if event.keyval in (gtk.keysyms.Return, gtk.keysyms.KP_Enter):
+            self.search_filter()
+
     def search_active(self, active=True, show_search=True):
 
         if active:
@@ -146,6 +151,8 @@ class Screen(signal_event.signal_event):
                 self.filter_widget.set_limit(self.limit)
                 self.screen_container.spin_limit.set_value(self.limit)
                 self.filter_widget.set_offset(self.screen_container.spin_offset.get_value())
+                self.screen_container.spin_limit.connect('key_press_event',self.get_event)
+                self.screen_container.spin_offset.connect('key_press_event',self.get_event)
 
         if active and show_search:
             self.screen_container.show_filter()
@@ -182,12 +189,12 @@ class Screen(signal_event.signal_event):
         self.search_filter()
 
     def search_limit_add(self, *args):
-        spin_limit_sc =  self.screen_container.spin_limit.get_value()
+        spin_limit_sc =  int(self.screen_container.spin_limit.get_text())
         self.filter_widget.set_limit(spin_limit_sc)
         return spin_limit_sc
 
     def search_offset_add(self, *args):
-        spin_offset_sc = self.screen_container.spin_offset.get_value()
+        spin_offset_sc = int(self.screen_container.spin_offset.get_text())
         self.filter_widget.set_offset(spin_offset_sc)
         return spin_offset_sc
 

--- a/bin/widget/view/screen_container.py
+++ b/bin/widget/view/screen_container.py
@@ -62,6 +62,21 @@ class screen_container(object):
         hb2.pack_start(self.but_previous, expand=False, fill=False)
         hb2.pack_start(self.but_next, expand=False, fill=False)
 
+        hb.pack_start(gtk.Label(_('Limit :')), expand=False, fill=False)
+        self.spin_limit = gtk.SpinButton(climb_rate=1, digits=0)
+        self.spin_limit.set_numeric(False)
+        self.spin_limit.set_adjustment(gtk.Adjustment(value=0, lower=0, upper=10000, step_incr=10, page_incr=100))
+        self.spin_limit.set_property('visible', True)
+        hb.pack_start(self.spin_limit, expand=False, fill=False)
+
+        hb.pack_start(gtk.Label(_('Offset :')), expand=False, fill=False)
+        self.spin_offset = gtk.SpinButton(climb_rate=1, digits=0)
+        self.spin_offset.set_numeric(False)
+        self.spin_offset.set_adjustment(gtk.Adjustment(value=0, lower=0, upper=10000, step_incr=80, page_incr=100))
+        self.spin_offset.set_property('visible', True)
+        hb.pack_start(self.spin_offset, expand=False, fill=False)
+
+
         button_clear = gtk.Button(stock=gtk.STOCK_CLEAR)
         button_clear.connect('clicked', clear_fnct)
         hb.pack_start(button_clear, expand=False, fill=False)

--- a/bin/widget_search/form.py
+++ b/bin/widget_search/form.py
@@ -140,22 +140,20 @@ class parse(object):
         self.dict_widget[str(attrs['name'])] = (widget_act, wid, int(val))
 
     def add_parameters(self):
-
         hb_param=gtk.HBox(spacing=3)
+
         hb_param.pack_start(gtk.Label(_('Limit :')), expand=False, fill=False)
-
-        self.spin_limit = gtk.SpinButton(climb_rate=1, digits=0)
-        self.spin_limit.set_numeric(False)
-        self.spin_limit.set_adjustment(gtk.Adjustment(value=80, lower=1, upper=sys.maxint, step_incr=10, page_incr=100))
-        self.spin_limit.set_property('visible', True)
-
+        self.spin_limit = gtk.SpinButton(climb_rate=1,digits=0)
+        self.spin_limit.set_numeric(True)
+        self.spin_limit.set_adjustment(gtk.Adjustment(value=80, lower=1, upper=sys.maxint))
+        self.spin_limit.set_sensitive(False)
         hb_param.pack_start(self.spin_limit, expand=False, fill=False)
 
         hb_param.pack_start(gtk.Label(_('Offset :')), expand=False, fill=False)
-
         self.spin_offset = gtk.SpinButton(climb_rate=1,digits=0)
-        self.spin_offset.set_numeric(False)
-        self.spin_offset.set_adjustment(gtk.Adjustment(value=0, lower=0, upper=sys.maxint, step_incr=80, page_incr=100))
+        self.spin_offset.set_numeric(True)
+        self.spin_offset.set_adjustment(gtk.Adjustment(value=0, lower=0, upper=sys.maxint))
+        self.spin_offset.set_sensitive(False)
 
         hb_param.pack_start(self.spin_offset, expand=False, fill=False)
 


### PR DESCRIPTION
* Se añaden `limit` y `offset` en el `screen_container` al lado del boton de búsqueda y de clear.
* Se deshabilitan para la edición los campos ya existentes en los filtros. El valor de éstos se actualitza. Se mantienen ambos para no romper ningún funcionamiento.

![image](https://user-images.githubusercontent.com/12842454/147262955-c5db44ad-d81d-4c0b-87eb-d1c1014e7d70.png)

![image](https://user-images.githubusercontent.com/12842454/147263000-df894d8b-bfa1-41e0-8128-3a319dc3fbc0.png)
